### PR TITLE
Alchemist v0.2.0 - SQLite/HashMap breakage (Resolves #33)

### DIFF
--- a/.env
+++ b/.env
@@ -1,1 +1,1 @@
-DATABASE_URL=postgres://localhost/alchemist
+DATABASE_URL=alchemist.db

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 Cargo.lock
+alchemist.db

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "Alchemist"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["Michael Gattozzi <mgattozzi@gmail.com>"]
 repository = "https://github.com/mgattozzi/Alchemist"
 homepage = "https://github.com/mgattozzi/Alchemist"
@@ -18,8 +18,8 @@ path = "src/bin/alchemist.rs"
 
 [dependencies]
 clap               = "*"
-diesel             = { git = "https://github.com/diesel-rs/diesel.git", features=["postgres"] }
-diesel_codegen     = { git = "https://github.com/diesel-rs/diesel.git", default-features = false, features=["nightly", "postgres"] }
+diesel             = { git = "https://github.com/diesel-rs/diesel.git", default-features = false, features=["sqlite"] }
+diesel_codegen     = { git = "https://github.com/diesel-rs/diesel.git", default-features = false, features=["nightly", "sqlite"] }
 dotenv             = "*"
 dotenv_macros      = "*"
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ this is far from production ready nightly is fine.
 For diesel:
 
 ```
-postgresql and it's dev libraries
+Sqlite3
 ```
 
 ###Setup

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -70,9 +70,10 @@ Open up the up.sql from the new migration and add the following:
 ```sql
 -- After packages include each of the distros located in the
 -- Packages struct in src/alchemy/models folder. You can
--- see what distros are in by checking the DB using psql
-INSERT INTO packages(arch, aur, ubuntu, ubuntu_dev) VALUES
-('postgresql',''postgresql','');
+-- see what distros are in by checking the DB using sqlite
+-- You'll also need to provide the correct id number for the db
+INSERT INTO packages(id,arch, aur, ubuntu, ubuntu_dev) VALUES
+(1,'postgresql',''postgresql','');
 
 -- Add more mappings to that list one for each distro in the order that
 -- you put for the first part of the statement. If no mapping exists you
@@ -88,7 +89,7 @@ DELETE FROM packages WHERE id > $ID_OF_PACKAGE_BEFORE_YOU_ADDED_NEW_ONES
 
 You can find out by running:
 ```
-psql -d alchemist
+sqlite3 alchemist.db
 SELECT * FROM packages;
 ```
 

--- a/migrations/20160428112233_packages_table/down.sql
+++ b/migrations/20160428112233_packages_table/down.sql
@@ -1,2 +1,1 @@
 DROP TABLE packages;
-DROP ROLE root;

--- a/migrations/20160428112233_packages_table/up.sql
+++ b/migrations/20160428112233_packages_table/up.sql
@@ -1,12 +1,9 @@
-CREATE ROLE root WITH LOGIN;
 CREATE TABLE packages (
-  id SERIAL PRIMARY KEY,
+  id int PRIMARY KEY NOT NULL,
   arch TEXT NOT NULL,
   aur TEXT NOT NULL,
   ubuntu TEXT NOT NULL,
   ubuntu_dev TEXT NOT NULL
 );
 
-GRANT SELECT ON packages TO root;
-
-INSERT INTO packages(arch, aur, ubuntu, ubuntu_dev) VALUES ('sudo','','sudo','');
+INSERT INTO packages(id,arch, aur, ubuntu, ubuntu_dev) VALUES (1,'sudo','','sudo','');

--- a/scripts/arch_setup.sh
+++ b/scripts/arch_setup.sh
@@ -1,12 +1,7 @@
 #!/bin/sh
 
-#Install depdendencies and set them up
-#sqlite is only included to get diesel_cli working
-sudo pacman -S postgresql postgresql-libs
-echo "Enabling postgresql"
-sudo systemctl enable postgresql
-echo "Starting postgresql"
-sudo systemctl start postgresql
+#Install db depdendency
+sudo pacman -S sqlite3
 
 #Install multirust
 curl -sf https://raw.githubusercontent.com/brson/multirust/master/blastoff.sh | sh
@@ -17,9 +12,8 @@ multirust update nightly
 multirust override nightly
 
 #Install diesel_cli and db
-createdb alchemist
 cargo install diesel_cli
-~/.cargo/bin/diesel migration run
+~/.cargo/bin/diesel setup
 echo "Add .cargo/bin to your PATH if you want to use diesel_cli everywhere"
 
 echo "The project is all setup!"

--- a/src/alchemy/arch.rs
+++ b/src/alchemy/arch.rs
@@ -115,6 +115,7 @@ pub fn upgrade_packages() {
 
 //AUR related functions and Data types
 
+#[allow(dead_code)]
 ///Enum representing all the AUR installers available
 enum AURHelper {
     ///User manually installs packages from the AUR

--- a/src/alchemy/db.rs
+++ b/src/alchemy/db.rs
@@ -32,7 +32,7 @@ fn establish_connection() -> SqliteConnection {
 /// let queryed = pack_query(packages);
 /// ```
 ///
-pub fn pack_query(mut input_packages: HashSet<String>) -> HashSet<Package> {
+pub fn pack_query(input_packages: HashSet<String>) -> HashSet<Package> {
     use schema::packages::dsl::*;
 
     let connection = establish_connection();
@@ -51,9 +51,9 @@ pub fn pack_query(mut input_packages: HashSet<String>) -> HashSet<Package> {
             .or(ubuntu_dev.eq(&i))
         )
         .get_results::<Package>(&connection)
-        .expect("Error loading packages"));
+        .unwrap_or(vec![Package::empty()]);
         for j in results {
-            output.insert(i)
+            output.insert(j);
         }
     }
 

--- a/src/alchemy/db.rs
+++ b/src/alchemy/db.rs
@@ -2,7 +2,7 @@ extern crate diesel;
 extern crate dotenv;
 
 use diesel::prelude::*;
-use diesel::pg::PgConnection;
+use diesel::sqlite::SqliteConnection;
 use dotenv::dotenv;
 use models::Package;
 use std::env;
@@ -10,14 +10,14 @@ use std::collections::HashSet;
 
 
 /// Establishes a connection to the Alchemist DB
-fn establish_connection() -> PgConnection {
+fn establish_connection() -> SqliteConnection {
     //Read from the .env file where the db is located
     //at so we can connect to it.
     dotenv().ok();
     let database_url = env::var("DATABASE_URL")
         .expect("DATABASE_URL must be set");
 
-    PgConnection::establish(&database_url)
+    SqliteConnection::establish(&database_url)
         .expect(&format!("Error connecting to {}", database_url))
 }
 
@@ -33,30 +33,28 @@ fn establish_connection() -> PgConnection {
 /// ```
 ///
 pub fn pack_query(mut input_packages: HashSet<String>) -> HashSet<Package> {
-    //These allow us to use schema specific references
-    //as well as functions like eq(), or(), and any()
-    //in our querys using diesel
-    use diesel::expression::dsl::*;
     use schema::packages::dsl::*;
 
     let connection = establish_connection();
 
-    //TODO Establish a way for Diesel to accept a HashSet
-    let query_input = input_packages
-        .drain().collect::<Vec<String>>();
-
-    let query_output = packages.filter(
-        arch.eq(any(&query_input))
-            .or(aur.eq(any(&query_input)))
-            .or(ubuntu.eq(any(&query_input)))
-            .or(ubuntu_dev.eq(any(&query_input)))
-        )
-        .load::<Package>(&connection)
-        .expect("Error loading packages");
-
     let mut output: HashSet<Package> = HashSet::new();
-    for i in query_output {
-        output.insert(i);
+
+    for i in input_packages {
+        //While this might look like O(n^2) complexity
+        //it's more closer to O(n) since most querys only
+        //return one or 2 results really. Still this seemed
+        //to be the only way to implement it well
+        let results = packages.filter(
+            arch.eq(&i)
+            .or(aur.eq(&i))
+            .or(ubuntu.eq(&i))
+            .or(ubuntu_dev.eq(&i))
+        )
+        .get_results::<Package>(&connection)
+        .expect("Error loading packages"));
+        for j in results {
+            output.insert(i)
+        }
     }
 
     output

--- a/src/alchemy/models.rs
+++ b/src/alchemy/models.rs
@@ -12,3 +12,17 @@ pub struct Package {
     /// Ubuntu Development Header Packages
     pub ubuntu_dev: String
 }
+
+impl Package {
+    ///Returns a Package with no data for instances of error handling
+    ///when connecting to the db and finding nothing
+    pub fn empty() -> Package {
+        Package {
+            id: 0,
+            arch: String::from(""),
+            aur : String::from(""),
+            ubuntu: String::from(""),
+            ubuntu_dev: String::from(""),
+        }
+    }
+}


### PR DESCRIPTION
Due to the fact that I rewrote everything to use sqlite rather than
using postgresql I'm bumping the version to v0.2.0 rather than doing
a minor bump. The benefit of this though is that many people already
have sqlite installed as a dependency on their system. The other benefit
of it is that it's much lighter on the system in terms of resources
making it real nice for a command line tool like Alchemist. The jump to
v0.2.0 makes sense because everything was switched from Vecs to HashSets
breaking anyone using code based off this.

Release Notes:

- HashSets rather than Vecs for increased efficiency and fitting the needs
  of how Alchemist works
- SQLite rather than Postgresql for lighter dev dependencies and less
  resources being used on the system.

Upgrade